### PR TITLE
feat: system tray icon with minimize-to-tray option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,7 +443,7 @@ dependencies = [
  "log",
  "num-rational",
  "num-traits",
- "pastey",
+ "pastey 0.1.1",
  "rayon",
  "thiserror 2.0.18",
  "v_frame",
@@ -1394,6 +1406,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "enum_dispatch"
@@ -3179,6 +3197,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ksni"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ca513d0be42df5edb485af9f44a12b2cb85af773d91c27dc796d1c58b78edc"
+dependencies = [
+ "futures-util",
+ "once_cell",
+ "pastey 0.2.2",
+ "serde",
+ "tokio",
+ "zbus 5.15.0",
+]
+
+[[package]]
 name = "kurbo"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4134,6 +4166,12 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "pathdiff"
@@ -5722,8 +5760,8 @@ dependencies = [
  "pollster",
  "thiserror 1.0.69",
  "windows 0.44.0",
- "zbus",
- "zvariant",
+ "zbus 3.15.2",
+ "zvariant 3.15.2",
 ]
 
 [[package]]
@@ -5815,6 +5853,7 @@ dependencies = [
  "image 0.25.10",
  "infer",
  "itertools",
+ "ksni",
  "librespot-core",
  "log",
  "lru",
@@ -6387,8 +6426,10 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.3",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -6932,6 +6973,7 @@ checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -7833,6 +7875,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winres"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8004,7 +8055,7 @@ version = "3.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
 dependencies = [
- "async-broadcast",
+ "async-broadcast 0.5.1",
  "async-executor",
  "async-fs",
  "async-io 1.13.0",
@@ -8034,9 +8085,39 @@ dependencies = [
  "uds_windows",
  "winapi",
  "xdg-home",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 3.15.2",
+ "zbus_names 2.6.1",
+ "zvariant 3.15.2",
+]
+
+[[package]]
+name = "zbus"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+dependencies = [
+ "async-broadcast 0.7.2",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener 5.4.1",
+ "futures-core",
+ "futures-lite 2.6.1",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.2",
+ "zbus_macros 5.15.0",
+ "zbus_names 4.3.2",
+ "zvariant 5.10.1",
 ]
 
 [[package]]
@@ -8050,7 +8131,22 @@ dependencies = [
  "quote",
  "regex",
  "syn 1.0.109",
- "zvariant_utils",
+ "zvariant_utils 1.0.1",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names 4.3.2",
+ "zvariant 5.10.1",
+ "zvariant_utils 3.3.1",
 ]
 
 [[package]]
@@ -8061,7 +8157,18 @@ checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
 dependencies = [
  "serde",
  "static_assertions",
- "zvariant",
+ "zvariant 3.15.2",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.2",
+ "zvariant 5.10.1",
 ]
 
 [[package]]
@@ -8186,7 +8293,21 @@ dependencies = [
  "libc",
  "serde",
  "static_assertions",
- "zvariant_derive",
+ "zvariant_derive 3.15.2",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db0ecb8987cf5e92653c57c098f7f0e39a03112edb796f4fe089fb7eaa14ff"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.2",
+ "zvariant_derive 5.10.1",
+ "zvariant_utils 3.3.1",
 ]
 
 [[package]]
@@ -8199,7 +8320,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "zvariant_utils",
+ "zvariant_utils 1.0.1",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b949b639ab1b4bed763aa7481ba0e368af68d8b55532f8ed4bec86a59f2ca98"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 3.3.1",
 ]
 
 [[package]]
@@ -8211,4 +8345,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.2",
 ]

--- a/spotix-gui/Cargo.toml
+++ b/spotix-gui/Cargo.toml
@@ -53,6 +53,7 @@ druid-shell = { version = "0.8.3", features = ["raw-win-handle"] }
 open = { version = "5.3.3" }
 raw-window-handle = "0.6.2" # Must stay compatible with Druid
 souvlaki = { version = "0.8.3", default-features = false, features = ["use_zbus"] }
+ksni = { version = "0.3", features = ["blocking"] }
 sanitize_html = "0.10.0"
 rustfm-scrobble = "1.1.1"
 [target.'cfg(windows)'.build-dependencies]

--- a/spotix-gui/src/cmd.rs
+++ b/spotix-gui/src/cmd.rs
@@ -20,6 +20,7 @@ pub const SHOW_MAIN: Selector = Selector::new("app.show-main");
 pub const SHOW_ACCOUNT_SETUP: Selector = Selector::new("app.show-initial");
 pub const CLOSE_ALL_WINDOWS: Selector = Selector::new("app.close-all-windows");
 pub const QUIT_APP_WITH_SAVE: Selector = Selector::new("app.quit-with-save");
+pub const TRAY_SHOW_WINDOW: Selector = Selector::new("app.tray.show-window");
 pub const SET_FOCUS: Selector = Selector::new("app.set-focus");
 pub const COPY: Selector<String> = Selector::new("app.copy-to-clipboard");
 pub const GO_TO_URL: Selector<String> = Selector::new("app.go-to-url");

--- a/spotix-gui/src/data/config.rs
+++ b/spotix-gui/src/data/config.rs
@@ -189,6 +189,8 @@ pub struct Config {
     pub lyrics_appearance: LyricsAppearance,
     /// Enable dynamic playing bar with album-art-derived colors and pulse.
     pub dynamic_playing_bar: bool,
+    /// Minimize to system tray when the main window is closed.
+    pub close_to_tray: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Data, Serialize, Deserialize)]
@@ -231,6 +233,7 @@ impl Default for Config {
             webapi_client_id: None,
             lyrics_appearance: LyricsAppearance::default(),
             dynamic_playing_bar: true,
+            close_to_tray: false,
         }
     }
 }

--- a/spotix-gui/src/delegate.rs
+++ b/spotix-gui/src/delegate.rs
@@ -1,7 +1,7 @@
 use directories::UserDirs;
 use druid::{
     AppDelegate, Application, Command, DelegateCtx, Env, Event, Handled, Target, WindowDesc,
-    WindowId, commands,
+    WindowHandle, WindowId, commands,
 };
 use std::fs;
 use threadpool::ThreadPool;
@@ -26,6 +26,7 @@ pub struct Delegate {
     artwork_window: Option<WindowId>,
     image_pool: ThreadPool,
     size_updated: bool,
+    tray_handle: Option<ksni::blocking::Handle<crate::tray::SpotixTray>>,
 }
 
 impl Delegate {
@@ -39,6 +40,7 @@ impl Delegate {
             artwork_window: None,
             image_pool: ThreadPool::with_name("image_loading".into(), MAX_IMAGE_THREADS),
             size_updated: false,
+            tray_handle: None,
         }
     }
 
@@ -131,6 +133,20 @@ impl Delegate {
 }
 
 impl AppDelegate<AppState> for Delegate {
+    fn window_added(
+        &mut self,
+        id: WindowId,
+        _handle: WindowHandle,
+        _data: &mut AppState,
+        _env: &Env,
+        ctx: &mut DelegateCtx,
+    ) {
+        if self.main_window == Some(id) && self.tray_handle.is_none() {
+            let sink = ctx.get_external_handle();
+            self.tray_handle = crate::tray::start_tray(sink);
+        }
+    }
+
     fn command(
         &mut self,
         ctx: &mut DelegateCtx,
@@ -139,7 +155,14 @@ impl AppDelegate<AppState> for Delegate {
         data: &mut AppState,
         _env: &Env,
     ) -> Handled {
-        if cmd.is(cmd::SHOW_CREDITS_WINDOW) {
+        if cmd.is(cmd::TRAY_SHOW_WINDOW) {
+            if let Some(id) = self.main_window {
+                ctx.submit_command(commands::SHOW_WINDOW.to(id));
+            } else {
+                self.show_main(&data.config, ctx);
+            }
+            Handled::Yes
+        } else if cmd.is(cmd::SHOW_CREDITS_WINDOW) {
             let _window_id = self.show_credits(ctx);
             if let Some(track) = cmd.get(cmd::SHOW_CREDITS_WINDOW) {
                 ctx.submit_command(
@@ -201,6 +224,8 @@ impl AppDelegate<AppState> for Delegate {
             ctx.submit_command(RENAME_PLAYLIST.with(link.clone()));
             Handled::Yes
         } else if cmd.is(cmd::QUIT_APP_WITH_SAVE) {
+            data.config.volume = data.playback.volume;
+            data.config.save();
             ctx.submit_command(commands::QUIT_APP);
             Handled::Yes
         } else if cmd.is(commands::QUIT_APP) {
@@ -254,6 +279,7 @@ impl AppDelegate<AppState> for Delegate {
         if self.main_window == Some(id) {
             data.config.volume = data.playback.volume;
             data.config.save();
+            self.main_window = None;
             ctx.submit_command(commands::CLOSE_ALL_WINDOWS);
             ctx.submit_command(commands::QUIT_APP);
         }

--- a/spotix-gui/src/main.rs
+++ b/spotix-gui/src/main.rs
@@ -6,6 +6,7 @@ mod controller;
 mod data;
 mod delegate;
 mod error;
+mod tray;
 mod ui;
 mod webapi;
 mod widget;

--- a/spotix-gui/src/tray.rs
+++ b/spotix-gui/src/tray.rs
@@ -1,0 +1,63 @@
+use druid::{ExtEventSink, Target};
+use ksni::blocking::TrayMethods;
+
+use crate::cmd;
+
+pub struct SpotixTray {
+    pub sink: ExtEventSink,
+}
+
+impl ksni::Tray for SpotixTray {
+    fn id(&self) -> String {
+        "spotix-tray".into()
+    }
+
+    fn title(&self) -> String {
+        "Spotix".into()
+    }
+
+    fn icon_name(&self) -> String {
+        "spotix".into()
+    }
+
+    fn menu(&self) -> Vec<ksni::MenuItem<Self>> {
+        use ksni::menu::*;
+        vec![
+            StandardItem {
+                label: "Open Spotix".into(),
+                activate: Box::new(|this: &mut Self| {
+                    let _ = this
+                        .sink
+                        .submit_command(cmd::TRAY_SHOW_WINDOW, (), Target::Global);
+                }),
+                ..Default::default()
+            }
+            .into(),
+            MenuItem::Separator,
+            StandardItem {
+                label: "Quit".into(),
+                activate: Box::new(|this: &mut Self| {
+                    let _ = this
+                        .sink
+                        .submit_command(cmd::QUIT_APP_WITH_SAVE, (), Target::Global);
+                }),
+                ..Default::default()
+            }
+            .into(),
+        ]
+    }
+}
+
+pub fn start_tray(sink: ExtEventSink) -> Option<ksni::blocking::Handle<SpotixTray>> {
+    let tray = SpotixTray { sink };
+    match tray.spawn() {
+        Ok(handle) => {
+            log::info!("tray: system tray icon started");
+            Some(handle)
+        }
+        Err(err) => {
+            log::warn!("tray: failed to start system tray icon: {err}");
+            None
+        }
+    }
+}

--- a/spotix-gui/src/ui/mod.rs
+++ b/spotix-gui/src/ui/mod.rs
@@ -58,8 +58,30 @@ pub mod utils;
 
 pub const DOWNLOAD_ARTWORK: Selector<(String, String)> = Selector::new("app.artwork.download");
 
+struct CloseTrayController;
+
+impl<W: Widget<AppState>> Controller<AppState, W> for CloseTrayController {
+    fn event(
+        &mut self,
+        child: &mut W,
+        ctx: &mut druid::EventCtx,
+        event: &druid::Event,
+        data: &mut AppState,
+        env: &Env,
+    ) {
+        if matches!(event, druid::Event::WindowCloseRequested) && data.config.close_to_tray {
+            data.config.volume = data.playback.volume;
+            data.config.save();
+            ctx.submit_command(druid::commands::HIDE_WINDOW.to(ctx.window_id()));
+            ctx.set_handled();
+            return;
+        }
+        child.event(ctx, event, data, env);
+    }
+}
+
 pub fn main_window(config: &Config) -> WindowDesc<AppState> {
-    let win = WindowDesc::new(root_widget())
+    let win = WindowDesc::new(root_widget().controller(CloseTrayController))
         .title(compute_main_window_title)
         .with_min_size((theme::grid(65.0), theme::grid(50.0)))
         .window_size(config.window_size)

--- a/spotix-gui/src/ui/preferences.rs
+++ b/spotix-gui/src/ui/preferences.rs
@@ -217,6 +217,13 @@ fn general_tab_widget() -> impl Widget<AppState> {
             .lens(AppState::config.then(Config::enable_pagination)),
     );
 
+    col = col.with_spacer(theme::grid(1.0));
+
+    col = col.with_child(
+        Checkbox::new("Minimize to system tray on close")
+            .lens(AppState::config.then(Config::close_to_tray)),
+    );
+
     col = col.with_spacer(theme::grid(3.0));
 
     // Lyrics appearance


### PR DESCRIPTION
Adds an optional system tray icon (StatusNotifierItem via `ksni`) so the app can keep playing in the background while the main window is closed.

## Changes

- New **Minimize to system tray on close** preference (off by default, in Settings → General).
- Tray menu exposes **Open Spotix** and **Quit** actions.
- Closing the main window hides it instead of quitting when the option is enabled; tray Quit saves volume/config before exiting.
- Tray icon is started lazily when the main window is added and is silently disabled (warn log) if no StatusNotifier host is available.

## Notes

- `ksni` is a pure-Rust StatusNotifierItem implementation over D-Bus — no GTK/C deps. Works on KDE, GNOME (with AppIndicator extension), XFCE, Sway/Waybar, etc.
- Linux/BSD only for now; macOS/Windows tray backends can be added in a follow-up if needed.

## Validation

- `cargo clippy -p spotix-gui -- -D warnings` — clean.
- `cargo build -p spotix-gui` — clean.