### PR TITLE
feat: Add custom Spotify client ID support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,11 +1931,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5112,9 +5114,9 @@ dependencies = [
 
 [[package]]
 name = "rspotify"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6b781f7f2b4afac99cd6cb9506a427a128601cd3206a59156fad095c7280e1"
+checksum = "f906f59b800945449fbcb8ae4e3bcc971e3350e116a560e7aafd5cfadc605a56"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5122,6 +5124,7 @@ dependencies = [
  "chrono",
  "futures",
  "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "log",
  "maybe-async",
  "rspotify-http",
@@ -5137,9 +5140,9 @@ dependencies = [
 
 [[package]]
 name = "rspotify-http"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc03fb2b9aa31f484f1d47ab62a70b836e26477d1ab1a97559c5ca43af186d"
+checksum = "35d53699d56aa4412f56321600b6c816288cb6f60af6311236f47f8329e9fe5e"
 dependencies = [
  "async-trait",
  "log",
@@ -5151,13 +5154,15 @@ dependencies = [
 
 [[package]]
 name = "rspotify-macros"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10364677556c46b4e9e922360979db311cd0d7e598eaf7861497b56068fdc9e4"
+checksum = "45373be0355f53d1ca1065b9585be9924c7090c4bdc327ebf5a7924feeea6325"
 
 [[package]]
 name = "rspotify-model"
-version = "0.15.3"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b95fb66a9915464f94c7ce94af7f7b429708583bfd6b612f165f335364a8c5"
 dependencies = [
  "chrono",
  "enum_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,4 @@ opt-level = 2
 
 [patch.crates-io]
 wrapped-vec = { path = "vendor/wrapped-vec" }
-rspotify-model = { path = "rspotify-model-patch" }
 librespot-playback = { path = "librespot-playback-patch" }

--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ cargo install --locked --path spotix-gui
 # --locked ensures the pinned dependency versions are used.
 ```
 
+### Optional Spotify Developer Client ID
+Spotix includes a default Spotify client ID, but heavy shared usage can trigger
+Spotify rate limits. If you see repeated 429 errors, create your own Spotify app:
+
+1. Open the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard).
+2. Create an app and enable Web API access.
+3. Add `http://127.0.0.1:8888/login` as a redirect URI.
+4. Copy the generated Client ID.
+5. In Spotix, open Settings -> Account and paste it into Spotify Developer Client ID.
+6. Re-authenticate with Spotify.
+
 ### Build from source
 ```shell
 cargo build

--- a/rspotify-model-patch/src/album.rs
+++ b/rspotify-model-patch/src/album.rs
@@ -10,6 +10,18 @@ use crate::{
     SimplifiedTrack,
 };
 
+fn empty_simplified_track_page() -> Page<SimplifiedTrack> {
+    Page {
+        href: String::new(),
+        items: Vec::new(),
+        limit: 0,
+        next: None,
+        offset: 0,
+        previous: None,
+        total: 0,
+    }
+}
+
 /// Simplified Album Object
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SimplifiedAlbum {
@@ -38,17 +50,23 @@ pub struct FullAlbum {
     pub artists: Vec<SimplifiedArtist>,
     pub album_type: AlbumType,
     pub available_markets: Option<Vec<String>>,
+    #[serde(default)]
     pub copyrights: Vec<Copyright>,
+    #[serde(default)]
     pub external_ids: HashMap<String, String>,
     pub external_urls: HashMap<String, String>,
+    #[serde(default)]
     pub genres: Vec<String>,
     pub href: String,
     pub id: AlbumId<'static>,
+    #[serde(default)]
     pub images: Vec<Image>,
     pub name: String,
+    #[serde(default)]
     pub popularity: u32,
     pub release_date: String,
     pub release_date_precision: DatePrecision,
+    #[serde(default = "empty_simplified_track_page")]
     pub tracks: Page<SimplifiedTrack>,
     /// Not documented in official Spotify docs, however most albums do contain this field
     pub label: Option<String>,

--- a/rspotify-model-patch/src/artist.rs
+++ b/rspotify-model-patch/src/artist.rs
@@ -19,12 +19,16 @@ pub struct SimplifiedArtist {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FullArtist {
     pub external_urls: HashMap<String, String>,
+    #[serde(default)]
     pub followers: Followers,
+    #[serde(default)]
     pub genres: Vec<String>,
     pub href: String,
     pub id: ArtistId<'static>,
+    #[serde(default)]
     pub images: Vec<Image>,
     pub name: String,
+    #[serde(default)]
     pub popularity: u32,
 }
 

--- a/rspotify-model-patch/src/playlist.rs
+++ b/rspotify-model-patch/src/playlist.rs
@@ -41,6 +41,7 @@ pub struct SimplifiedPlaylist {
     pub owner: PublicUser,
     pub public: Option<bool>,
     pub snapshot_id: String,
+    #[serde(default)]
     pub tracks: PlaylistTracksRef,
 }
 
@@ -50,6 +51,7 @@ pub struct FullPlaylist {
     pub collaborative: bool,
     pub description: Option<String>,
     pub external_urls: HashMap<String, String>,
+    #[serde(default)]
     pub followers: Followers,
     pub href: String,
     pub id: PlaylistId<'static>,
@@ -59,6 +61,7 @@ pub struct FullPlaylist {
     pub owner: PublicUser,
     pub public: Option<bool>,
     pub snapshot_id: String,
+    #[serde(default)]
     pub tracks: Page<PlaylistItem>,
 }
 

--- a/rspotify-model-patch/src/show.rs
+++ b/rspotify-model-patch/src/show.rs
@@ -31,6 +31,7 @@ pub struct SimplifiedShow {
     pub languages: Vec<String>,
     pub media_type: String,
     pub name: String,
+    #[serde(default)]
     pub publisher: String,
 }
 
@@ -64,6 +65,7 @@ pub struct FullShow {
     pub languages: Vec<String>,
     pub media_type: String,
     pub name: String,
+    #[serde(default)]
     pub publisher: String,
 }
 

--- a/rspotify-model-patch/src/track.rs
+++ b/rspotify-model-patch/src/track.rs
@@ -35,6 +35,7 @@ pub struct FullTrack {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub restrictions: Option<Restriction>,
     pub name: String,
+    #[serde(default)]
     pub popularity: u32,
     pub preview_url: Option<String>,
     pub track_number: u32,

--- a/spotix-gui/Cargo.toml
+++ b/spotix-gui/Cargo.toml
@@ -40,11 +40,11 @@ ureq = { version = "3.2.0", features = ["json", "socks-proxy"] }
 url = { version = "2.5.8" }
 infer = "0.19.0"
 tokio = { version = "1.50.0", features = ["rt", "time"] }
-rspotify = { version = "0.15.3", features = ["cli"] }
+rspotify = { version = "0.16.1", features = ["cli"] }
 maybe-async = "0.2.10"
 async-trait = "0.1.89"
 chrono = "0.4.44"
-rspotify-http = "0.15.3"
+rspotify-http = "0.16.1"
 librespot-core = "0.8.0"
 
 # GUI

--- a/spotix-gui/src/data/config.rs
+++ b/spotix-gui/src/data/config.rs
@@ -339,6 +339,8 @@ impl Config {
     pub fn effective_webapi_client_id(&self) -> &str {
         self.webapi_client_id
             .as_deref()
+            .map(str::trim)
+            .filter(|client_id| !client_id.is_empty())
             .unwrap_or(spotix_core::session::access_token::CLIENT_ID)
     }
 

--- a/spotix-gui/src/ui/preferences.rs
+++ b/spotix-gui/src/ui/preferences.rs
@@ -56,6 +56,23 @@ where
         )
 }
 
+struct WebApiClientIdLens;
+
+impl Lens<AppState, String> for WebApiClientIdLens {
+    fn with<V, F: FnOnce(&String) -> V>(&self, data: &AppState, f: F) -> V {
+        let value = data.config.webapi_client_id.clone().unwrap_or_default();
+        f(&value)
+    }
+
+    fn with_mut<V, F: FnOnce(&mut String) -> V>(&self, data: &mut AppState, f: F) -> V {
+        let mut value = data.config.webapi_client_id.clone().unwrap_or_default();
+        let result = f(&mut value);
+        let value = value.trim().to_string();
+        data.config.webapi_client_id = (!value.is_empty()).then_some(value);
+        result
+    }
+}
+
 pub fn account_setup_widget() -> impl Widget<AppState> {
     Flex::column()
         .must_fill_main_axis(true)
@@ -711,6 +728,10 @@ fn account_tab_widget(tab: AccountTab) -> impl Widget<AppState> {
             .with_spacer(theme::grid(2.0));
     }
 
+    col = col
+        .with_child(spotify_client_id_section())
+        .with_spacer(theme::grid(2.0));
+
     // Spotify Login/Logout button
     col = col
         .with_child(ViewSwitcher::new(
@@ -784,6 +805,31 @@ fn account_tab_widget(tab: AccountTab) -> impl Widget<AppState> {
             ));
     }
     col.controller(Authenticate::new(tab))
+}
+
+fn spotify_client_id_section() -> impl Widget<AppState> {
+    Flex::column()
+        .cross_axis_alignment(CrossAxisAlignment::Start)
+        .with_child(Label::new("Spotify Developer Client ID").with_font(theme::UI_FONT_MEDIUM))
+        .with_spacer(theme::grid(1.0))
+        .with_child(
+            Label::new(
+                "Optional. Use your own Spotify app client ID to avoid shared-client rate limits. \
+                 Add http://127.0.0.1:8888/login as the redirect URL in Spotify Developer settings.",
+            )
+            .with_text_color(theme::PLACEHOLDER_COLOR)
+            .with_line_break_mode(LineBreaking::WordWrap),
+        )
+        .with_spacer(theme::grid(1.0))
+        .with_child(make_input_row(
+            "Client ID:",
+            "Leave empty to use Spotix default",
+            WebApiClientIdLens,
+        ))
+        .with_spacer(theme::grid(1.0))
+        .with_child(Button::new("Open Spotify Developer Dashboard").on_click(|_, _, _| {
+            open::that("https://developer.spotify.com/dashboard").ok();
+        }))
 }
 
 fn lastfm_connected_view() -> impl Widget<AppState> {
@@ -921,7 +967,7 @@ impl Authenticate {
         data.preferences.auth.result.defer_default();
 
         // Generate auth URL and store PKCE verifier
-        let client_id = WebApi::global().webapi_client_id().to_string();
+        let client_id = data.config.effective_webapi_client_id().to_string();
         let (auth_url, pkce_verifier) = oauth::generate_auth_url(8888, &client_id);
         let config = data.preferences.auth.session_config(); // Keep config local
 
@@ -1098,6 +1144,8 @@ impl<W: Widget<AppState>> Controller<AppState, W> for Authenticate {
                         // Always store the OAuth token for Web API access
                         data.config.store_oauth_token(payload.oauth_token.clone());
                         data.config.save();
+                        WebApi::global()
+                            .set_webapi_client_id(data.config.effective_webapi_client_id());
                         WebApi::global().set_oauth_token(payload.oauth_token.clone());
                         WebApi::global().clear_rate_limit_state();
 

--- a/spotix-gui/src/ui/search.rs
+++ b/spotix-gui/src/ui/search.rs
@@ -20,7 +20,7 @@ use crate::{
 use super::{album, artist, playable, playlist, theme, track, utils};
 
 const NUMBER_OF_RESULTS_PER_TOPIC: usize = 5;
-const INDIVIDUAL_TOPIC_RESULTS_LIMIT: usize = 50;
+const INDIVIDUAL_TOPIC_RESULTS_LIMIT: usize = 10;
 
 pub const LOAD_RESULTS: Selector<(Arc<str>, Option<SearchTopic>)> =
     Selector::new("app.search.load-results");

--- a/spotix-gui/src/webapi/client.rs
+++ b/spotix-gui/src/webapi/client.rs
@@ -25,8 +25,7 @@ use log::info;
 use parking_lot::{Condvar, Mutex};
 use rspotify::clients::{BaseClient, OAuthClient};
 use rspotify::model::{
-    AlbumType as RSpotifyAlbumType, ArtistId, Market, PlayableItem, PlaylistId, SearchType,
-    TimeRange,
+    AlbumType as RSpotifyAlbumType, ArtistId, PlayableItem, PlaylistId, SearchType, TimeRange,
 };
 use rspotify::prelude::Id;
 use rspotify::{ClientError, Token as RSpotifyToken};
@@ -872,7 +871,7 @@ impl WebApi {
     fn user_profile_from_rspotify(&self, user: rspotify::model::PrivateUser) -> UserProfile {
         UserProfile {
             display_name: Arc::from(user.display_name.unwrap_or_default()),
-            email: Arc::from(user.email.unwrap_or_default()),
+            email: Arc::from(""),
             id: Arc::from(user.id.id()),
         }
     }
@@ -883,7 +882,7 @@ impl WebApi {
             name: Arc::from(playlist.name),
             images: Some(self.images_from_rspotify(playlist.images)),
             description: Arc::from(""),
-            track_count: Some(playlist.tracks.total as usize),
+            track_count: Some(playlist.items.total as usize),
             owner: self.public_user_from_rspotify(playlist.owner),
             collaborative: playlist.collaborative,
             public: playlist.public,
@@ -896,7 +895,7 @@ impl WebApi {
             name: Arc::from(playlist.name),
             images: Some(self.images_from_rspotify(playlist.images)),
             description: sanitize_html_string(playlist.description.as_deref().unwrap_or_default()),
-            track_count: Some(playlist.tracks.total as usize),
+            track_count: Some(playlist.items.total as usize),
             owner: self.public_user_from_rspotify(playlist.owner),
             collaborative: playlist.collaborative,
             public: playlist.public,
@@ -904,10 +903,7 @@ impl WebApi {
     }
 
     fn album_type_from_meta(&self, album: &rspotify::model::SimplifiedAlbum) -> AlbumType {
-        let group = album
-            .album_group
-            .as_deref()
-            .or(album.album_type.as_deref());
+        let group = album.album_type.as_deref();
         match group {
             Some("single") => AlbumType::Single,
             Some("compilation") => AlbumType::Compilation,
@@ -1563,7 +1559,7 @@ impl WebApi {
                                 RSpotifyAlbumType::Compilation,
                                 RSpotifyAlbumType::AppearsOn,
                             ],
-                            Some(Market::FromToken),
+                            None,
                             Some(limit),
                             Some(offset),
                         )
@@ -1611,6 +1607,7 @@ impl WebApi {
         self.get_artist_top_tracks_with_policy(id, CachePolicy::Refresh)
     }
 
+    #[allow(deprecated)]
     fn get_artist_top_tracks_with_policy(
         &self,
         id: &str,
@@ -1622,7 +1619,7 @@ impl WebApi {
             self.load_cached_value_rspotify("artist-top-tracks", id, policy, || {
                 self.rspotify_call(|| {
                     self.rspotify
-                        .artist_top_tracks(artist_id.as_ref(), Some(Market::FromToken))
+                        .artist_top_tracks(artist_id.as_ref(), None)
                 })
             })?;
         Ok(self
@@ -1775,8 +1772,7 @@ impl WebApi {
         id: &str,
         policy: CachePolicy,
     ) -> Result<Cached<Arc<Album>>, Error> {
-        let request = &RequestBuilder::new(format!("v1/albums/{id}"), Method::Get, None)
-            .query("market", "from_token");
+        let request = &RequestBuilder::new(format!("v1/albums/{id}"), Method::Get, None);
         let result = self.load_cached_with(request, "album", id, policy)?;
         Ok(result)
     }
@@ -1798,8 +1794,7 @@ impl WebApi {
         id: &str,
         policy: CachePolicy,
     ) -> Result<Cached<Arc<Show>>, Error> {
-        let request = &RequestBuilder::new(format!("v1/shows/{id}"), Method::Get, None)
-            .query("market", "from_token");
+        let request = &RequestBuilder::new(format!("v1/shows/{id}"), Method::Get, None);
 
         let result = self.load_cached_with(request, "show", id, policy)?;
 
@@ -1821,16 +1816,14 @@ impl WebApi {
         let id_list = ids.iter().map(|id| id.0.to_base62()).join(",");
         let cache_key = Self::cache_key(&id_list);
         let request = &RequestBuilder::new("v1/episodes", Method::Get, None)
-            .query("ids", &id_list)
-            .query("market", "from_token");
+            .query("ids", &id_list);
         let (result, _) =
             self.load_cached_value::<Episodes>(request, "episodes", &cache_key, policy)?;
         Ok(result.episodes)
     }
 
     pub fn get_episode(&self, id: &str) -> Result<Arc<Episode>, Error> {
-        let request = &RequestBuilder::new(format!("v1/episodes/{id}"), Method::Get, None)
-            .query("market", "from_token");
+        let request = &RequestBuilder::new(format!("v1/episodes/{id}"), Method::Get, None);
         let result: Cached<Arc<Episode>> = self.load_cached(request, "episode", id)?;
         Ok(result.data)
     }
@@ -1851,8 +1844,7 @@ impl WebApi {
         id: &str,
         policy: CachePolicy,
     ) -> Result<Vector<Arc<Episode>>, Error> {
-        let request = &RequestBuilder::new(format!("v1/shows/{id}/episodes"), Method::Get, None)
-            .query("market", "from_token");
+        let request = &RequestBuilder::new(format!("v1/shows/{id}/episodes"), Method::Get, None);
 
         let mut results = Vector::new();
         self.for_all_pages_cached(
@@ -1881,8 +1873,7 @@ impl WebApi {
 impl WebApi {
     // https://developer.spotify.com/documentation/web-api/reference/get-track
     pub fn get_track(&self, id: &str) -> Result<Arc<Track>, Error> {
-        let request = &RequestBuilder::new(format!("v1/tracks/{id}"), Method::Get, None)
-            .query("market", "from_token");
+        let request = &RequestBuilder::new(format!("v1/tracks/{id}"), Method::Get, None);
         let result = self.load_cached(request, "track", id)?;
         Ok(result.data)
     }
@@ -1938,8 +1929,7 @@ impl WebApi {
             album: Arc<Album>,
         }
 
-        let request =
-            &RequestBuilder::new("v1/me/albums", Method::Get, None).query("market", "from_token");
+        let request = &RequestBuilder::new("v1/me/albums", Method::Get, None);
 
         Ok(self
             .load_all_pages_cached(request, "saved-albums", "all", CachePolicy::Use)?
@@ -1970,8 +1960,7 @@ impl WebApi {
         struct SavedTrack {
             track: Arc<Track>,
         }
-        let request =
-            &RequestBuilder::new("v1/me/tracks", Method::Get, None).query("market", "from_token");
+        let request = &RequestBuilder::new("v1/me/tracks", Method::Get, None);
         Ok(self
             .load_all_pages_cached(request, "saved-tracks", "all", CachePolicy::Use)?
             .into_iter()
@@ -1986,8 +1975,7 @@ impl WebApi {
             show: Arc<Show>,
         }
 
-        let request =
-            &RequestBuilder::new("v1/me/shows", Method::Get, None).query("market", "from_token");
+        let request = &RequestBuilder::new("v1/me/shows", Method::Get, None);
 
         Ok(self
             .load_all_pages_cached(request, "saved-shows", "all", CachePolicy::Use)?
@@ -2184,7 +2172,7 @@ impl WebApi {
                     self.rspotify.playlist_items_manual(
                         playlist_id.as_ref(),
                         None,
-                        Some(Market::FromToken),
+                        None,
                         Some(limit as u32),
                         Some(offset as u32),
                     )
@@ -2197,7 +2185,7 @@ impl WebApi {
             .into_iter()
             .enumerate()
             .filter_map(|(index, item)| {
-                let mut track = match item.track {
+                let mut track = match item.item {
                     Some(PlayableItem::Track(track)) => {
                         let track = self.rspotify_to::<Track, _>(&track).ok()?;
                         Arc::new(track)
@@ -2358,7 +2346,7 @@ impl WebApi {
                     self.rspotify.search_multiple(
                         query,
                         types,
-                        Some(Market::FromToken),
+                        None,
                         None,
                         Some(limit as u32),
                         None,

--- a/spotix-gui/src/webapi/client.rs
+++ b/spotix-gui/src/webapi/client.rs
@@ -88,7 +88,7 @@ pub struct WebApi {
     paginated_limit: usize,
     rate_limiter: Mutex<RateLimiter>,
     request_gate: RequestGate,
-    webapi_client_id: String,
+    webapi_client_id: Mutex<String>,
     /// Set when an OAuth refresh token is revoked. Checked by the UI
     /// to show a re-authentication prompt.
     oauth_revoked: std::sync::atomic::AtomicBool,
@@ -174,7 +174,7 @@ impl WebApi {
             paginated_limit,
             rate_limiter: Mutex::new(rate_limiter),
             request_gate: RequestGate::new(8),
-            webapi_client_id,
+            webapi_client_id: Mutex::new(webapi_client_id),
             oauth_revoked: std::sync::atomic::AtomicBool::new(false),
         }
     }
@@ -262,7 +262,8 @@ impl WebApi {
                 log::warn!("webapi: oauth token expired but no refresh token available");
                 return Ok(None);
             };
-            match oauth::refresh_access_token(&refresh_token, &self.webapi_client_id) {
+            let client_id = self.webapi_client_id.lock().clone();
+            match oauth::refresh_access_token(&refresh_token, &client_id) {
                 Ok(refreshed) => {
                     log::info!("webapi: refreshed oauth access token");
                     *guard = Some(refreshed.clone());
@@ -656,7 +657,8 @@ impl WebApi {
                 log::warn!("webapi: oauth token expired but no refresh token available");
                 return Ok(None);
             };
-            match oauth::refresh_access_token(&refresh_token, &self.webapi_client_id) {
+            let client_id = self.webapi_client_id.lock().clone();
+            match oauth::refresh_access_token(&refresh_token, &client_id) {
                 Ok(refreshed) => {
                     log::info!("webapi: refreshed oauth access token");
                     *guard = Some(refreshed.clone());
@@ -1449,15 +1451,15 @@ impl WebApi {
             .store(false, std::sync::atomic::Ordering::SeqCst);
     }
 
+    pub fn set_webapi_client_id(&self, client_id: &str) {
+        *self.webapi_client_id.lock() = client_id.to_string();
+    }
+
     /// Check and clear the OAuth revocation flag. Returns `true` once
     /// after a revocation, then `false` until the next one.
     pub fn take_oauth_revoked(&self) -> bool {
         self.oauth_revoked
             .swap(false, std::sync::atomic::Ordering::SeqCst)
-    }
-
-    pub fn webapi_client_id(&self) -> &str {
-        &self.webapi_client_id
     }
 
     pub fn is_rate_limited(&self) -> bool {


### PR DESCRIPTION
## Summary

- Add an optional Spotify Developer Client ID field to Account preferences.
- Use the configured Client ID for OAuth authorization and token refresh to help avoid shared-client Web API rate limits.
- Hot-apply the Client ID after successful re-authentication so users do not need to restart Spotix.
- Keep login5/client-token internals on the built-in Spotix Client ID because Spotify rejects regular Developer app IDs for those flows.
- Document Spotify app setup, Web API access, redirect URI configuration, and re-authentication steps.
- Relax rspotify model deserialization for partial Spotify responses that omit fields like `followers`, `tracks`, and `popularity`.
